### PR TITLE
Add package prefix for ownership

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "autopush-manager",
+  "name": "@bitwarden/autopush-manager",
   "version": "0.1.0",
   "description": "A module to subscribe to Mozilla Autopush and receive notifications",
   "scripts": {


### PR DESCRIPTION
## 🎟️ Tracking

Noticed in our security scanning tools, due to a false positive.

## 📔 Objective

Name matching may be used to find vulnerabilities or malware, and we should prefix our package name with Bitwarden organization ownership.
